### PR TITLE
PLAT3-1377; added allowedMethods for master branch registration

### DIFF
--- a/.github/workflows/pr-name-check.yml
+++ b/.github/workflows/pr-name-check.yml
@@ -13,5 +13,5 @@ jobs:
       id: lint-pr-title
       uses: LabelNexus/regex-for-gh-actions@master
       with:
-        pattern: '([A-Z]{2,}\-\d+;)'
+        pattern: '([A-Z0-9]{2,}\-\d+;)'
         string: ${{ github.event.pull_request.title }}

--- a/route_decorator.py
+++ b/route_decorator.py
@@ -71,7 +71,7 @@ def __authenticate(request_type):
     g.org_id = token_data.get('orgId')
 
   try:
-    
+
     if request.path == os.environ.get('WIDGET_URL_PREFIX') + 'status' and request.method == 'POST':
       service_data = request.get_json(True)
       g.service_data = service_data['serviceData']
@@ -183,6 +183,7 @@ def add_url_rule(func, wrapped, path, methods, request_type, security_types, is_
   all_routes.append({
     'path': '^' + regex_path + '$',
     'security': [x.name for x in security_types],
+    'allowedMethods': methods,
     'type': request_type.name,
     'isManage': str(is_manage).lower()
   })


### PR DESCRIPTION
This change should be on both master and base-model branches until they can be safely merged together.  This passes through to godspeed and redis route registration what request method types are allowed for a route.  