### PR TITLE
PLAT3-2121 always promote updates to bust cache if no state is provided.

### DIFF
--- a/base_asset/behavior/asset_rest.py
+++ b/base_asset/behavior/asset_rest.py
@@ -69,7 +69,7 @@ class AssetRestBehavior(RestBehavior):
 
     response_data = super().put(record_id)
     asset_response = {
-      'state': asset_update_data.get('state'),
+      'state': asset_update_data.get('state', 'promoted'),
       'payload': response_data
     }
     return asset_response


### PR DESCRIPTION
Assets should bust cache on updates if no other state is provided(forms provide various states).  