### PR TITLE
PLAT3-2271 delete multiple objects

### DIFF
--- a/aws/client.py
+++ b/aws/client.py
@@ -107,6 +107,16 @@ class AwsClient(object):
           Bucket=self.default_bucket_name,
           Key=key)
 
+  def delete_objects(self, path_list):
+    if not path_list:
+      return
+
+    matching_keys = [{'Key': k} for k in path_list]
+    response = self.s3_client.delete_objects(
+      Bucket=self.default_bucket_name,
+      Delete={'Objects': matching_keys, 'Quiet': True})
+    return response
+
   def get_all_versions(self, key):
     keys = ["Versions", "DeleteMarkers"]
     results = []

--- a/aws/file.py
+++ b/aws/file.py
@@ -73,6 +73,12 @@ class FileBehavior(object):
     if full_path is not None:
       self.__client.delete_object(full_path)
 
+  def delete_objects(self, path_list):
+    if not path_list:
+      return
+
+    self.__client.delete_objects(path_list)
+
   def get_full_path(self, path=None, file_name=None):
     if file_name is None:
       file_name = self.__client.objects.generate_unique_key()


### PR DESCRIPTION
This might not work for versioned buckets if its anything like a single delete, but I can't test it locally since my bucket isn't versioned.  If that's the case, I might need to get all object versions for all files to be deleted first ,then call delete for all versions like we do for a single file delete.