### PR TITLE
PLAT3-3639; expose sort so it may be overriden

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ class BaseAsset:
   from .base_asset import SettingsModel
   from .base_asset import DataColumn
   from .base_asset import DataRestFilter
+  from .base_asset import DataRestSort
   from .base_asset import FileFilter
 
   from .base_asset import AssetAccessRestBehavior

--- a/base_asset/__init__.py
+++ b/base_asset/__init__.py
@@ -3,6 +3,7 @@ from .behavior import AssetAccessRestBehavior
 from .behavior import SettingsRestBehavior
 from .behavior import DataAssetRestBehavior
 from .behavior import DataRestBehavior
+from .behavior import DataRestSort
 from .behavior import FileAssetRestBehavior
 
 from .column import DataColumn

--- a/base_asset/behavior/__init__.py
+++ b/base_asset/behavior/__init__.py
@@ -2,5 +2,5 @@ from .asset_rest import AssetRestBehavior
 from .asset_access_rest import AssetAccessRestBehavior
 from .settings_rest import SettingsRestBehavior
 from .data_asset_rest import DataAssetRestBehavior
-from .data_rest import DataRestBehavior, DataRestFilter
+from .data_rest import DataRestBehavior, DataRestFilter, DataRestSort
 from .file_asset_rest import FileAssetRestBehavior


### PR DESCRIPTION
Product needs the sort field to be overriden due to columns living in a "columns" field.